### PR TITLE
TinyCLIP integration for ActionCLIP

### DIFF
--- a/clip/clip.py
+++ b/clip/clip.py
@@ -15,7 +15,6 @@ from tqdm import tqdm
 from .model import build_model
 from .simple_tokenizer import SimpleTokenizer as _Tokenizer
 
-CLIP_backbones = ["vanilla_CLIP, tiny_CLIP"]
 __all__ = ["available_models", "load", "tokenize"]
 _tokenizer = _Tokenizer()
 

--- a/clip/clip.py
+++ b/clip/clip.py
@@ -21,21 +21,30 @@ _tokenizer = _Tokenizer()
 
 _MODELS = {
     "ViT-B/32": "https://openaipublic.azureedge.net/clip/models/40d365715913c9da98579312b702a82c18be219cc2a73407c4526f58eba950af/ViT-B-32.pt",
-    "ViT-B/16": "https://openaipublic.azureedge.net/clip/models/5806e77cd80f8b59890b7e101eabd078d9fb84e6937f9e85e4ecb61988df416f/ViT-B-16.pt"
-}
+    "ViT-B/16": "https://openaipublic.azureedge.net/clip/models/5806e77cd80f8b59890b7e101eabd078d9fb84e6937f9e85e4ecb61988df416f/ViT-B-16.pt",
+    "TinyCLIP-ViT-40M/32-Text-19M": "https://github.com/wkcn/TinyCLIP-model-zoo/releases/download/checkpoints/TinyCLIP-ViT-40M-32-Text-19M-LAION400M.pt",
+    "TinyCLIP-ViT-61M/32-Text-29M": "https://github.com/wkcn/TinyCLIP-model-zoo/releases/download/checkpoints/TinyCLIP-ViT-61M-32-Text-29M-LAION400M.pt",
+}   
 
-def _download(url: str, root: str = os.path.expanduser("~/.cache/clip")):
+def _download(url: str, root: str = os.path.expanduser("~/.cache/clip"), skip_sha256 = True):
+    '''Download CLIP model to cache. Optionally, skip_sha256 checksum skips
+    the checksum to allow for downloading the official TinyCLIP models because 
+    they are not supplied.'''
     os.makedirs(root, exist_ok=True)
     filename = os.path.basename(url)
 
     expected_sha256 = url.split("/")[-2]
     download_target = os.path.join(root, filename)
-
+        
     if os.path.exists(download_target) and not os.path.isfile(download_target):
         raise RuntimeError(f"{download_target} exists and is not a regular file")
-
+    
     if os.path.isfile(download_target):
-        if hashlib.sha256(open(download_target, "rb").read()).hexdigest() == expected_sha256:
+        # TinyCLIP does not come with checksum, return
+        # download target early
+        if skip_sha256: 
+            return download_target
+        elif hashlib.sha256(open(download_target, "rb").read()).hexdigest() == expected_sha256:
             return download_target
         else:
             warnings.warn(f"{download_target} exists, but the SHA256 checksum does not match; re-downloading the file")
@@ -46,12 +55,11 @@ def _download(url: str, root: str = os.path.expanduser("~/.cache/clip")):
                 buffer = source.read(8192)
                 if not buffer:
                     break
-
                 output.write(buffer)
                 loop.update(len(buffer))
-
-    if hashlib.sha256(open(download_target, "rb").read()).hexdigest() != expected_sha256:
-        raise RuntimeError(f"Model has been downloaded but the SHA256 checksum does not not match")
+    if not skip_sha256:
+        if hashlib.sha256(open(download_target, "rb").read()).hexdigest() != expected_sha256:
+            raise RuntimeError(f"Model has been downloaded but the SHA256 checksum does not not match")
 
     return download_target
 

--- a/clip/clip.py
+++ b/clip/clip.py
@@ -7,7 +7,6 @@ import os
 import urllib
 import warnings
 from typing import Union, List
-
 import torch
 from PIL import Image
 from torchvision.transforms import Compose, Resize, CenterCrop, ToTensor, Normalize
@@ -16,12 +15,13 @@ from tqdm import tqdm
 from .model import build_model
 from .simple_tokenizer import SimpleTokenizer as _Tokenizer
 
+CLIP_backbones = ["vanilla_CLIP, tiny_CLIP"]
 __all__ = ["available_models", "load", "tokenize"]
 _tokenizer = _Tokenizer()
 
 _MODELS = {
-    "ViT-B/32": "https://openaipublic.azureedge.net/clip/models/40d365715913c9da98579312b702a82c18be219cc2a73407c4526f58eba950af/ViT-B-32.pt",
-    "ViT-B/16": "https://openaipublic.azureedge.net/clip/models/5806e77cd80f8b59890b7e101eabd078d9fb84e6937f9e85e4ecb61988df416f/ViT-B-16.pt",
+    "CLIP-ViT-B/32": "https://openaipublic.azureedge.net/clip/models/40d365715913c9da98579312b702a82c18be219cc2a73407c4526f58eba950af/ViT-B-32.pt",
+    "CLIP-ViT-B/16": "https://openaipublic.azureedge.net/clip/models/5806e77cd80f8b59890b7e101eabd078d9fb84e6937f9e85e4ecb61988df416f/ViT-B-16.pt",
     "TinyCLIP-ViT-40M/32-Text-19M": "https://github.com/wkcn/TinyCLIP-model-zoo/releases/download/checkpoints/TinyCLIP-ViT-40M-32-Text-19M-LAION400M.pt",
     "TinyCLIP-ViT-61M/32-Text-29M": "https://github.com/wkcn/TinyCLIP-model-zoo/releases/download/checkpoints/TinyCLIP-ViT-61M-32-Text-29M-LAION400M.pt",
 }   
@@ -120,8 +120,9 @@ def load(name: str, device: Union[str, torch.device] = "cuda" if torch.cuda.is_a
         state_dict = torch.load(model_path, map_location="cpu")
 
     if not jit:
-
-        model = build_model(state_dict or model.state_dict(), joint=joint,tsm=tsm,T=T,dropout=dropout, emb_dropout=emb_dropout,pretrain=pretrain).to(device)
+        # Split on first '-' to decide whether CLIP or TinyCLIP is backbone
+        clip_name = str.split(name, "-")[0]
+        model = build_model(state_dict or model.state_dict(), joint=joint,tsm=tsm,T=T,dropout=dropout, emb_dropout=emb_dropout,pretrain=pretrain, clip_backbone=clip_name).to(device)
         if str(device) == "cpu":
             model.float()
         

--- a/configs/hmdb51/hmdb_test.yaml
+++ b/configs/hmdb51/hmdb_test.yaml
@@ -18,7 +18,7 @@ data:
         N: 0 #2
         M: 0  #9
 network:
-    arch: ViT-B/16  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
+    arch: CLIP-ViT-B/16  #CLIP-ViT-B/32 CLIP-ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True 
     drop_out: 0.0 
     emb_dropout: 0.0

--- a/configs/hmdb51/hmdb_test.yaml
+++ b/configs/hmdb51/hmdb_test.yaml
@@ -18,7 +18,7 @@ data:
         N: 0 #2
         M: 0  #9
 network:
-    arch: ViT-B/16  #ViT-B/32 ViT-B/16
+    arch: ViT-B/16  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True 
     drop_out: 0.0 
     emb_dropout: 0.0

--- a/configs/hmdb51/hmdb_train.yaml
+++ b/configs/hmdb51/hmdb_train.yaml
@@ -21,7 +21,7 @@ data:
         N: 0 #2
         M: 0  #9
 network:
-    arch: ViT-B/16  #ViT-B/32 ViT-B/16
+    arch: ViT-B/16  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True 
     drop_out: 0.0 
     emb_dropout: 0.0 

--- a/configs/hmdb51/hmdb_train.yaml
+++ b/configs/hmdb51/hmdb_train.yaml
@@ -21,7 +21,7 @@ data:
         N: 0 #2
         M: 0  #9
 network:
-    arch: ViT-B/16  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
+    arch: CLIP-ViT-B/16  #CLIP-ViT-B/32 CLIP-ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True 
     drop_out: 0.0 
     emb_dropout: 0.0 

--- a/configs/hmdb51/hmdb_zero_shot.yaml
+++ b/configs/hmdb51/hmdb_zero_shot.yaml
@@ -18,7 +18,7 @@ data:
         N: 0 #2
         M: 0  #9
 network:
-    arch: ViT-B/16  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
+    arch: CLIP-ViT-B/16  #CLIP-ViT-B/32 CLIP-ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True
     drop_out: 0.0
     emb_dropout: 0.0

--- a/configs/hmdb51/hmdb_zero_shot.yaml
+++ b/configs/hmdb51/hmdb_zero_shot.yaml
@@ -18,7 +18,7 @@ data:
         N: 0 #2
         M: 0  #9
 network:
-    arch: ViT-B/16  #ViT-B/32 ViT-B/16
+    arch: ViT-B/16  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True
     drop_out: 0.0
     emb_dropout: 0.0

--- a/configs/k400/k400_test.yaml
+++ b/configs/k400/k400_test.yaml
@@ -17,7 +17,7 @@ data:
     input_size: 224
     random_shift: False
 network:
-    arch: ViT-B/32  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
+    arch: CLIP-ViT-B/16  #CLIP-ViT-B/32 CLIP-ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True
     tsm: False
     drop_out: 0.0 

--- a/configs/k400/k400_test.yaml
+++ b/configs/k400/k400_test.yaml
@@ -17,7 +17,7 @@ data:
     input_size: 224
     random_shift: False
 network:
-    arch: ViT-B/32  #ViT-B/32 ViT-B/16
+    arch: ViT-B/32  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True
     tsm: False
     drop_out: 0.0 

--- a/configs/k400/k400_train.yaml
+++ b/configs/k400/k400_train.yaml
@@ -20,7 +20,7 @@ data:
         M: 9  #9
     random_shift: True
 network:
-    arch: ViT-B/32  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
+    arch: CLIP-ViT-B/16  #CLIP-ViT-B/32 CLIP-ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True
     tsm: False
     drop_out: 0.0 

--- a/configs/k400/k400_train.yaml
+++ b/configs/k400/k400_train.yaml
@@ -20,7 +20,7 @@ data:
         M: 9  #9
     random_shift: True
 network:
-    arch: ViT-B/32  #ViT-B/32 ViT-B/16
+    arch: ViT-B/32  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True
     tsm: False
     drop_out: 0.0 

--- a/configs/k400/k400_zero_shot.yaml
+++ b/configs/k400/k400_zero_shot.yaml
@@ -16,7 +16,7 @@ data:
     input_size: 224
     random_shift: False
 network:
-    arch: ViT-B/32  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
+    arch: CLIP-ViT-B/16  #CLIP-ViT-B/32 CLIP-ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True
     tsm: False
     drop_out: 0.0 # probability of an element to be zeroed

--- a/configs/k400/k400_zero_shot.yaml
+++ b/configs/k400/k400_zero_shot.yaml
@@ -16,7 +16,7 @@ data:
     input_size: 224
     random_shift: False
 network:
-    arch: ViT-B/32  #ViT-B/32 ViT-B/16
+    arch: ViT-B/32  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True
     tsm: False
     drop_out: 0.0 # probability of an element to be zeroed

--- a/configs/ucf101/ucf_test.yaml
+++ b/configs/ucf101/ucf_test.yaml
@@ -18,7 +18,7 @@ data:
         N: 0 #2
         M: 0  #9
 network:
-    arch: ViT-B/16  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
+    arch: CLIP-ViT-B/16  #CLIP-ViT-B/32 CLIP-ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True 
     drop_out: 0.0 
     emb_dropout: 0.0 

--- a/configs/ucf101/ucf_test.yaml
+++ b/configs/ucf101/ucf_test.yaml
@@ -18,7 +18,7 @@ data:
         N: 0 #2
         M: 0  #9
 network:
-    arch: ViT-B/16  #ViT-B/32 ViT-B/16
+    arch: ViT-B/16  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True 
     drop_out: 0.0 
     emb_dropout: 0.0 

--- a/configs/ucf101/ucf_train.yaml
+++ b/configs/ucf101/ucf_train.yaml
@@ -21,7 +21,7 @@ data:
         N: 0 #2
         M: 0  #9
 network:
-    arch: ViT-B/16  #ViT-B/32 ViT-B/16
+    arch: ViT-B/16  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True  
     drop_out: 0.0 
     emb_dropout: 0.0 

--- a/configs/ucf101/ucf_train.yaml
+++ b/configs/ucf101/ucf_train.yaml
@@ -21,7 +21,7 @@ data:
         N: 0 #2
         M: 0  #9
 network:
-    arch: ViT-B/16  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
+    arch: CLIP-ViT-B/16  #CLIP-ViT-B/32 CLIP-ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True  
     drop_out: 0.0 
     emb_dropout: 0.0 

--- a/configs/ucf101/ucf_zero_shot.yaml
+++ b/configs/ucf101/ucf_zero_shot.yaml
@@ -18,7 +18,7 @@ data:
         N: 0 #2
         M: 0  #9
 network:
-    arch: ViT-B/16  #ViT-B/32 ViT-B/16
+    arch: ViT-B/16  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True
     drop_out: 0.0
     emb_dropout: 0.0 

--- a/configs/ucf101/ucf_zero_shot.yaml
+++ b/configs/ucf101/ucf_zero_shot.yaml
@@ -18,7 +18,7 @@ data:
         N: 0 #2
         M: 0  #9
 network:
-    arch: ViT-B/16  #ViT-B/32 ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
+    arch: CLIP-ViT-B/16  #CLIP-ViT-B/32 CLIP-ViT-B/16 TinyCLIP-ViT-61M/32-Text-29M TinyCLIP-ViT-40M/32-Text-19M
     init: True
     drop_out: 0.0
     emb_dropout: 0.0 


### PR DESCRIPTION
This PR integrates two TinyCLIP ViT models to the existing model framework with minimal changes. This is possible because TinyCLIP provides a pure ViT-based model, like CLIP. The TinyCLIP model is a CLIP distillation that provides significant speed-ups to the CLIP model while retaining and in some cases improving its zero-shot IN1K accuracy. A small state_dict conversion helper method and optional sha256 ignore flag are added to accommodate for this integration.
 

[The TinyCLIP paper](
https://openaccess.thecvf.com/content/ICCV2023/html/Wu_TinyCLIP_CLIP_Distillation_via_Affinity_Mimicking_and_Weight_Inheritance_ICCV_2023_paper.html)

[The TinyCLIP models (Git) ](https://github.com/microsoft/Cream/tree/main/TinyCLIP)

Graphs below show rough indication of ActionCLIP during train time on HMDB51 (no pre-train). Train step indicates the batches processed per minute (wall clock) time. TinyCLIP-based ActionCLIP model trains much faster while performance is almost similar to vanilla CLIP. 
![wandb_comparison](https://github.com/sallymmx/ActionCLIP/assets/25344665/5fe8e2f8-e9c3-44fb-9cc5-a425f1b48079)
